### PR TITLE
World persist and restore

### DIFF
--- a/hatchery/src/instance.rs
+++ b/hatchery/src/instance.rs
@@ -208,7 +208,7 @@ impl Instance {
         self.id
     }
 
-    pub fn set_snapshot_id(&mut self, snapshot_id: SnapshotId) {
+    pub(crate) fn set_snapshot_id(&mut self, snapshot_id: SnapshotId) {
         self.snapshot_id = Some(snapshot_id);
     }
     pub fn snapshot_id(&self) -> Option<&SnapshotId> {

--- a/hatchery/src/instance.rs
+++ b/hatchery/src/instance.rs
@@ -17,8 +17,8 @@ use wasmer::NativeFunc;
 
 use crate::error::*;
 use crate::memory::MemHandler;
-use crate::world::World;
 use crate::snapshot::SnapshotId;
+use crate::world::World;
 
 #[derive(Debug)]
 pub struct Instance {
@@ -208,8 +208,7 @@ impl Instance {
         self.id
     }
 
-    pub fn set_snapshot_id(&mut self, snapshot_id: SnapshotId)
-    {
+    pub fn set_snapshot_id(&mut self, snapshot_id: SnapshotId) {
         self.snapshot_id = Some(snapshot_id);
     }
     pub fn snapshot_id(&self) -> Option<&SnapshotId> {

--- a/hatchery/src/instance.rs
+++ b/hatchery/src/instance.rs
@@ -18,6 +18,7 @@ use wasmer::NativeFunc;
 use crate::error::*;
 use crate::memory::MemHandler;
 use crate::world::World;
+use crate::snapshot::SnapshotId;
 
 #[derive(Debug)]
 pub struct Instance {
@@ -29,6 +30,7 @@ pub struct Instance {
     arg_buf_len: i32,
     heap_base: i32,
     self_id_ofs: i32,
+    snapshot_id: Option<SnapshotId>,
 }
 
 impl Instance {
@@ -52,6 +54,7 @@ impl Instance {
             arg_buf_len,
             heap_base,
             self_id_ofs,
+            snapshot_id: None,
         }
     }
 
@@ -205,6 +208,13 @@ impl Instance {
         self.id
     }
 
+    pub fn set_snapshot_id(&mut self, snapshot_id: SnapshotId)
+    {
+        self.snapshot_id = Some(snapshot_id);
+    }
+    pub fn snapshot_id(&self) -> Option<&SnapshotId> {
+        self.snapshot_id.as_ref()
+    }
     pub(crate) fn world(&self) -> &World {
         &self.world
     }

--- a/hatchery/src/lib.rs
+++ b/hatchery/src/lib.rs
@@ -8,6 +8,7 @@ mod env;
 mod error;
 mod instance;
 mod memory;
+mod snapshot;
 mod storage_helpers;
 mod world;
 

--- a/hatchery/src/snapshot.rs
+++ b/hatchery/src/snapshot.rs
@@ -1,0 +1,132 @@
+use crate::error::Error;
+use crate::storage_helpers::{
+    combine_module_snapshot_names, snapshot_id_to_name,
+};
+use crate::Error::PersistenceError;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use rkyv::{Archive, Deserialize, Serialize};
+pub const SNAPSHOT_ID_BYTES: usize = 32;
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Archive,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+)]
+#[repr(C)]
+pub struct SnapshotId([u8; SNAPSHOT_ID_BYTES]);
+impl SnapshotId {
+    pub const fn uninitialized() -> Self {
+        SnapshotId([0u8; SNAPSHOT_ID_BYTES])
+    }
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+impl From<[u8; 32]> for SnapshotId {
+    fn from(array: [u8; 32]) -> Self {
+        SnapshotId(array)
+    }
+}
+
+pub trait SnapshotLike {
+    fn path(&self) -> &PathBuf;
+    /// Read's snapshot's content into buffer
+    fn read(&self) -> Result<Vec<u8>, Error> {
+        let mut f = std::fs::File::open(self.path().as_path())
+            .map_err(PersistenceError)?;
+        let metadata = std::fs::metadata(self.path().as_path())
+            .map_err(PersistenceError)?;
+        let mut buffer = vec![0; metadata.len() as usize];
+        f.read(buffer.as_mut_slice()).map_err(PersistenceError)?;
+        Ok(buffer)
+    }
+}
+
+pub struct MemoryPath {
+    path: PathBuf,
+}
+
+impl MemoryPath {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        MemoryPath {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl SnapshotLike for MemoryPath {
+    fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}
+
+
+pub struct Snapshot {
+    path: PathBuf,
+    id: SnapshotId,
+}
+
+impl Snapshot {
+    pub fn new(memory_path: &MemoryPath) -> Result<Self, Error> {
+        let snapshot_id: SnapshotId =
+            SnapshotId::from(*blake3::hash(memory_path.read()?.as_slice()).as_bytes());
+        Snapshot::from_id(snapshot_id, memory_path)
+    }
+
+    pub fn from_id(
+        snapshot_id: SnapshotId,
+        memory_path: &MemoryPath,
+    ) -> Result<Self, Error> {
+        let mut path = memory_path.path().to_owned();
+        path.set_file_name(combine_module_snapshot_names(
+            path.file_name()
+                .expect("filename exists")
+                .to_str()
+                .expect("filename is UTF8"),
+            snapshot_id_to_name(snapshot_id),
+        ));
+        Ok(Snapshot {
+            path,
+            id: snapshot_id,
+        })
+    }
+
+    /// Saves current snapshot as uncompressed file.
+    pub fn save_uncompressed(
+        &self,
+        memory_path: &MemoryPath,
+    ) -> Result<(), Error> {
+        std::fs::copy(memory_path.path(), self.path().as_path())
+            .map_err(PersistenceError)?;
+        Ok(())
+    }
+
+    /// Restores current snapshot from uncompressed file.
+    pub fn load_uncompressed(
+        &self,
+        memory_path: &MemoryPath,
+    ) -> Result<(), Error> {
+        std::fs::copy(self.path().as_path(), memory_path.path())
+            .map_err(PersistenceError)?;
+        Ok(())
+    }
+
+    pub fn id(&self) -> SnapshotId {
+        self.id
+    }
+}
+
+impl SnapshotLike for Snapshot {
+    fn path(&self) -> &PathBuf {
+        &self.path
+    }
+}

--- a/hatchery/src/snapshot.rs
+++ b/hatchery/src/snapshot.rs
@@ -27,12 +27,8 @@ pub const SNAPSHOT_ID_BYTES: usize = 32;
     Clone,
     Copy,
 )]
-#[repr(C)]
 pub struct SnapshotId([u8; SNAPSHOT_ID_BYTES]);
 impl SnapshotId {
-    pub const fn uninitialized() -> Self {
-        SnapshotId([0u8; SNAPSHOT_ID_BYTES])
-    }
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
@@ -107,7 +103,7 @@ impl Snapshot {
     }
 
     /// Saves current snapshot as uncompressed file.
-    pub fn save_uncompressed(
+    pub fn save(
         &self,
         memory_path: &MemoryPath,
     ) -> Result<(), Error> {
@@ -117,7 +113,7 @@ impl Snapshot {
     }
 
     /// Restores current snapshot from uncompressed file.
-    pub fn load_uncompressed(
+    pub fn load(
         &self,
         memory_path: &MemoryPath,
     ) -> Result<(), Error> {

--- a/hatchery/src/snapshot.rs
+++ b/hatchery/src/snapshot.rs
@@ -69,7 +69,6 @@ impl SnapshotLike for MemoryPath {
     }
 }
 
-
 pub struct Snapshot {
     path: PathBuf,
     id: SnapshotId,
@@ -77,8 +76,9 @@ pub struct Snapshot {
 
 impl Snapshot {
     pub fn new(memory_path: &MemoryPath) -> Result<Self, Error> {
-        let snapshot_id: SnapshotId =
-            SnapshotId::from(*blake3::hash(memory_path.read()?.as_slice()).as_bytes());
+        let snapshot_id: SnapshotId = SnapshotId::from(
+            *blake3::hash(memory_path.read()?.as_slice()).as_bytes(),
+        );
         Snapshot::from_id(snapshot_id, memory_path)
     }
 

--- a/hatchery/src/snapshot.rs
+++ b/hatchery/src/snapshot.rs
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use crate::error::Error;
 use crate::storage_helpers::{
     combine_module_snapshot_names, snapshot_id_to_name,

--- a/hatchery/src/snapshot.rs
+++ b/hatchery/src/snapshot.rs
@@ -103,20 +103,14 @@ impl Snapshot {
     }
 
     /// Saves current snapshot as uncompressed file.
-    pub fn save(
-        &self,
-        memory_path: &MemoryPath,
-    ) -> Result<(), Error> {
+    pub fn save(&self, memory_path: &MemoryPath) -> Result<(), Error> {
         std::fs::copy(memory_path.path(), self.path().as_path())
             .map_err(PersistenceError)?;
         Ok(())
     }
 
     /// Restores current snapshot from uncompressed file.
-    pub fn load(
-        &self,
-        memory_path: &MemoryPath,
-    ) -> Result<(), Error> {
+    pub fn load(&self, memory_path: &MemoryPath) -> Result<(), Error> {
         std::fs::copy(self.path().as_path(), memory_path.path())
             .map_err(PersistenceError)?;
         Ok(())

--- a/hatchery/src/storage_helpers.rs
+++ b/hatchery/src/storage_helpers.rs
@@ -15,16 +15,16 @@ pub fn combine_module_snapshot_names(
 }
 
 pub fn module_id_to_name(module_id: ModuleId) -> String {
-    format!("{}", ByteArrayWrapper(Box::from(module_id.as_bytes())))
+    format!("{}", ByteArrayWrapper(module_id.as_bytes()))
 }
 
 pub fn snapshot_id_to_name(snapshot_id: SnapshotId) -> String {
-    format!("{}", ByteArrayWrapper(Box::from(snapshot_id.as_bytes())))
+    format!("{}", ByteArrayWrapper(snapshot_id.as_bytes()))
 }
 
-struct ByteArrayWrapper(pub Box<[u8]>);
+struct ByteArrayWrapper<'a>(pub &'a[u8]);
 
-impl core::fmt::UpperHex for ByteArrayWrapper {
+impl<'a> core::fmt::UpperHex for ByteArrayWrapper<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let bytes = &self.0[..];
         if f.alternate() {
@@ -37,7 +37,7 @@ impl core::fmt::UpperHex for ByteArrayWrapper {
     }
 }
 
-impl core::fmt::Display for ByteArrayWrapper {
+impl<'a> core::fmt::Display for ByteArrayWrapper<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::UpperHex::fmt(self, f)
     }

--- a/hatchery/src/storage_helpers.rs
+++ b/hatchery/src/storage_helpers.rs
@@ -22,7 +22,7 @@ pub fn snapshot_id_to_name(snapshot_id: SnapshotId) -> String {
     format!("{}", ByteArrayWrapper(snapshot_id.as_bytes()))
 }
 
-struct ByteArrayWrapper<'a>(pub &'a[u8]);
+struct ByteArrayWrapper<'a>(pub &'a [u8]);
 
 impl<'a> core::fmt::UpperHex for ByteArrayWrapper<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/hatchery/src/storage_helpers.rs
+++ b/hatchery/src/storage_helpers.rs
@@ -26,11 +26,10 @@ struct ByteArrayWrapper<'a>(&'a [u8]);
 
 impl<'a> core::fmt::UpperHex for ByteArrayWrapper<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let bytes = &self.0[..];
         if f.alternate() {
             write!(f, "0x")?
         }
-        for byte in bytes {
+        for byte in self.0 {
             write!(f, "{:02X}", &byte)?
         }
         Ok(())

--- a/hatchery/src/storage_helpers.rs
+++ b/hatchery/src/storage_helpers.rs
@@ -22,7 +22,7 @@ pub fn snapshot_id_to_name(snapshot_id: SnapshotId) -> String {
     format!("{}", ByteArrayWrapper(snapshot_id.as_bytes()))
 }
 
-struct ByteArrayWrapper<'a>(pub &'a [u8]);
+struct ByteArrayWrapper<'a>(&'a [u8]);
 
 impl<'a> core::fmt::UpperHex for ByteArrayWrapper<'a> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/hatchery/src/storage_helpers.rs
+++ b/hatchery/src/storage_helpers.rs
@@ -4,17 +4,29 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
+use crate::snapshot::SnapshotId;
 use dallo::ModuleId;
 
-pub fn module_id_to_filename(module_id: ModuleId) -> String {
-    format!("{}", ModuleIdWrapper(module_id))
+pub fn combine_module_snapshot_names(
+    module_name: impl AsRef<str>,
+    snapshot_name: impl AsRef<str>,
+) -> String {
+    format!("{}_{}", module_name.as_ref(), snapshot_name.as_ref())
 }
 
-struct ModuleIdWrapper(pub ModuleId);
+pub fn module_id_to_name(module_id: ModuleId) -> String {
+    format!("{}", ByteArrayWrapper(Box::from(module_id.as_bytes())))
+}
 
-impl core::fmt::UpperHex for ModuleIdWrapper {
+pub fn snapshot_id_to_name(snapshot_id: SnapshotId) -> String {
+    format!("{}", ByteArrayWrapper(Box::from(snapshot_id.as_bytes())))
+}
+
+struct ByteArrayWrapper(pub Box<[u8]>);
+
+impl core::fmt::UpperHex for ByteArrayWrapper {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let bytes = self.0.as_bytes();
+        let bytes = &self.0[..];
         if f.alternate() {
             write!(f, "0x")?
         }
@@ -25,7 +37,7 @@ impl core::fmt::UpperHex for ModuleIdWrapper {
     }
 }
 
-impl core::fmt::Display for ModuleIdWrapper {
+impl core::fmt::Display for ByteArrayWrapper {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::UpperHex::fmt(self, f)
     }

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -24,9 +24,9 @@ use crate::env::Env;
 use crate::error::Error;
 use crate::instance::Instance;
 use crate::memory::MemHandler;
+use crate::snapshot::{MemoryPath, Snapshot, SnapshotLike};
 use crate::storage_helpers::module_id_to_name;
 use crate::Error::PersistenceError;
-use crate::snapshot::{MemoryPath, Snapshot, SnapshotLike};
 
 #[derive(Debug)]
 pub struct WorldInner {
@@ -85,7 +85,11 @@ impl World {
             let snapshot = Snapshot::new(&memory_path)?;
             environment.inner_mut().set_snapshot_id(snapshot.id());
             snapshot.save_uncompressed(&memory_path)?;
-            println!("persisted state of module: {:?} to file: {:?}", module_id_to_name(*module_id), snapshot.path());
+            println!(
+                "persisted state of module: {:?} to file: {:?}",
+                module_id_to_name(*module_id),
+                snapshot.path()
+            );
         }
         Ok(())
     }
@@ -97,7 +101,11 @@ impl World {
             if let Some(snapshot_id) = environment.inner().snapshot_id() {
                 let snapshot = Snapshot::from_id(*snapshot_id, &memory_path)?;
                 snapshot.load_uncompressed(&memory_path)?;
-                println!("restored state of module: {:?} from file: {:?}", module_id_to_name(*module_id), snapshot.path());
+                println!(
+                    "restored state of module: {:?} from file: {:?}",
+                    module_id_to_name(*module_id),
+                    snapshot.path()
+                );
             }
         }
         Ok(())
@@ -109,9 +117,7 @@ impl World {
         let id_bytes: [u8; MODULE_ID_BYTES] = blake3::hash(bytecode).into();
         let id = ModuleId::from(id_bytes);
         let store = wasmer::Store::new_with_path(
-            self.storage_path()
-                .join(module_id_to_name(id))
-                .as_path(),
+            self.storage_path().join(module_id_to_name(id)).as_path(),
         );
         let module = wasmer::Module::new(&store, bytecode)?;
 

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -84,7 +84,7 @@ impl World {
             let memory_path = MemoryPath::new(self.memory_path(module_id));
             let snapshot = Snapshot::new(&memory_path)?;
             environment.inner_mut().set_snapshot_id(snapshot.id());
-            snapshot.save_uncompressed(&memory_path)?;
+            snapshot.save(&memory_path)?;
             println!(
                 "persisted state of module: {:?} to file: {:?}",
                 module_id_to_name(*module_id),
@@ -100,7 +100,7 @@ impl World {
             let memory_path = MemoryPath::new(self.memory_path(module_id));
             if let Some(snapshot_id) = environment.inner().snapshot_id() {
                 let snapshot = Snapshot::from_id(*snapshot_id, &memory_path)?;
-                snapshot.load_uncompressed(&memory_path)?;
+                snapshot.load(&memory_path)?;
                 println!(
                     "restored state of module: {:?} from file: {:?}",
                     module_id_to_name(*module_id),

--- a/hatchery/tests/boxen.rs
+++ b/hatchery/tests/boxen.rs
@@ -55,3 +55,25 @@ pub fn box_set_store_restore_get() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+pub fn world_persist_restore() -> Result<(), Error> {
+    let mut world = World::ephemeral()?;
+    let id = world.deploy(module_bytecode!("box"))?;
+
+    let _: Receipt<()> = world.transact(id, "set", 17)?;
+    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    assert_eq!(*value, Some(17));
+
+    world.persist()?;
+
+    let _: Receipt<()> = world.transact(id, "set", 18)?;
+    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    assert_eq!(*value, Some(18));
+
+    world.restore()?;
+    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    assert_eq!(*value, Some(17));
+
+    Ok(())
+}


### PR DESCRIPTION
World persist and restore functionality.
State of all modules can be persisted and then restored, without redeployment of modules.
Implemented mechanism is verified by test `world_persist_restore` contained in file `boxen.rs`.
This PR solves issue #26.