### PR TITLE
Add RawQuery, RawTransaction, RawResult.

### DIFF
--- a/dallo/src/helpers.rs
+++ b/dallo/src/helpers.rs
@@ -17,9 +17,9 @@ pub type StandardBufSerializer<'a> = CompositeSerializer<
     BufferScratch<&'a mut [u8; SCRATCH_BUF_BYTES]>,
 >;
 
-/// Wrap a query with its respcective (de)serializers.
+/// Wrap a query with its respective (de)serializers.
 ///
-/// Returns the length of result written to buffer.
+/// Returns the length of result written to the buffer.
 pub fn wrap_query<A, R, F>(buf: &mut [u8], arg_len: u32, f: F) -> u32
 where
     A: Archive,
@@ -41,9 +41,9 @@ where
     composite.pos() as u32
 }
 
-/// Wrap a transaction with its respcective (de)serializers.
+/// Wrap a transaction with its respective (de)serializers.
 ///
-/// Returns the length of result written to buffer.
+/// Returns the length of result written to the buffer.
 pub fn wrap_transaction<A, R, F>(buf: &mut [u8], arg_len: u32, f: F) -> u32
 where
     A: Archive,

--- a/dallo/src/lib.rs
+++ b/dallo/src/lib.rs
@@ -26,7 +26,7 @@ mod types;
 pub use types::*;
 
 /// How many bytes to use for scratch space when serializing
-pub const SCRATCH_BUF_BYTES: usize = 16;
+pub const SCRATCH_BUF_BYTES: usize = 64;
 
 #[cfg(not(feature = "std"))]
 mod handlers;

--- a/dallo/src/state.rs
+++ b/dallo/src/state.rs
@@ -6,35 +6,48 @@
 
 use core::cell::UnsafeCell;
 use rkyv::{
-    archived_value,
+    archived_root,
     ser::serializers::{BufferScratch, BufferSerializer, CompositeSerializer},
     ser::Serializer,
     Archive, Deserialize, Infallible, Serialize,
 };
 
-use crate::Ser;
+use crate::{
+    RawQuery, RawResult, RawTransaction, StandardBufSerializer,
+    SCRATCH_BUF_BYTES,
+};
 
 extern "C" {
-    fn q(mod_id: *const u8, name: *const u8, len: i32, arg_ofs: i32) -> i32;
-    fn t(mod_id: *const u8, name: *const u8, len: i32, arg_ofs: i32) -> i32;
+    fn q(
+        mod_id: *const u8,
+        name: *const u8,
+        name_len: u32,
+        arg_len: u32,
+    ) -> u32;
+    fn t(
+        mod_id: *const u8,
+        name: *const u8,
+        name_len: u32,
+        arg_len: u32,
+    ) -> u32;
 
     fn height() -> i32;
-    fn caller() -> i32;
-    fn emit(arg_ofs: i32, arg_len: i32);
+    fn caller() -> u32;
+    fn emit(arg_len: u32);
 }
 
-fn extern_query(module_id: ModuleId, name: &str, arg_ofs: i32) -> i32 {
+fn extern_query(module_id: ModuleId, name: &str, arg_len: u32) -> u32 {
     let mod_ptr = module_id.as_ptr();
-    let nme_ptr = name.as_ptr();
-    let nme_len = name.as_bytes().len() as i32;
-    unsafe { q(mod_ptr, nme_ptr, nme_len, arg_ofs) }
+    let name_ptr = name.as_ptr();
+    let name_len = name.as_bytes().len() as u32;
+    unsafe { q(mod_ptr, name_ptr, name_len, arg_len) }
 }
 
-fn extern_transaction(module_id: ModuleId, name: &str, arg_ofs: i32) -> i32 {
+fn extern_transaction(module_id: ModuleId, name: &str, arg_len: u32) -> u32 {
     let mod_ptr = module_id.as_ptr();
-    let nme_ptr = name.as_ptr();
-    let nme_len = name.as_bytes().len() as i32;
-    unsafe { t(mod_ptr, nme_ptr, nme_len, arg_ofs) }
+    let name_ptr = name.as_ptr();
+    let name_len = name.as_bytes().len() as u32;
+    unsafe { t(mod_ptr, name_ptr, name_len, arg_len) }
 }
 
 use crate::ModuleId;
@@ -83,27 +96,58 @@ impl<S> DerefMut for State<S> {
 impl<S> State<S> {
     pub fn query<Arg, Ret>(&self, mod_id: ModuleId, name: &str, arg: Arg) -> Ret
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>>,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
-        let arg_ofs = self.with_arg_buf(|buf| {
-            let mut sbuf = [0u8; 16];
+        let arg_len = self.with_arg_buf(|buf| {
+            let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
             let scratch = BufferScratch::new(&mut sbuf);
             let ser = BufferSerializer::new(buf);
             let mut composite =
                 CompositeSerializer::new(ser, scratch, rkyv::Infallible);
 
-            composite.serialize_value(&arg).unwrap() as i32
+            composite.serialize_value(&arg).expect("infallible");
+            composite.pos() as u32
         });
 
-        let ret_ofs = extern_query(mod_id, name, arg_ofs);
+        let ret_len = extern_query(mod_id, name, arg_len);
 
         self.with_arg_buf(|buf| {
-            let ret = unsafe { archived_value::<Ret>(buf, ret_ofs as usize) };
-
+            let slice = &buf[..ret_len as usize];
+            let ret = unsafe { archived_root::<Ret>(slice) };
             ret.deserialize(&mut Infallible).expect("Infallible")
         })
+    }
+
+    pub fn query_raw(&self, mod_id: ModuleId, raw: RawQuery) -> RawResult {
+        self.with_arg_buf(|buf| {
+            let bytes = raw.arg_bytes();
+            buf[..bytes.len()].copy_from_slice(bytes);
+        });
+
+        let name = raw.name();
+        let arg_len = raw.arg_bytes().len() as u32;
+        let ret_len = extern_query(mod_id, name, arg_len);
+
+        self.with_arg_buf(|buf| RawResult::new(&buf[..ret_len as usize]))
+    }
+
+    pub fn transact_raw(
+        &self,
+        mod_id: ModuleId,
+        raw: RawTransaction,
+    ) -> RawResult {
+        self.with_arg_buf(|buf| {
+            let bytes = raw.arg_bytes();
+            buf[..bytes.len()].copy_from_slice(bytes);
+        });
+
+        let name = raw.name();
+        let arg_len = raw.arg_bytes().len() as u32;
+        let ret_len = extern_query(mod_id, name, arg_len);
+
+        self.with_arg_buf(|buf| RawResult::new(&buf[..ret_len as usize]))
     }
 
     pub fn transact<Arg, Ret>(
@@ -113,24 +157,26 @@ impl<S> State<S> {
         arg: Arg,
     ) -> Ret
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>>,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
-        let arg_ofs = self.with_arg_buf(|buf| {
-            let mut sbuf = [0u8; 16];
+        let arg_len = self.with_arg_buf(|buf| {
+            let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
             let scratch = BufferScratch::new(&mut sbuf);
             let ser = BufferSerializer::new(buf);
             let mut composite =
                 CompositeSerializer::new(ser, scratch, rkyv::Infallible);
 
-            composite.serialize_value(&arg).unwrap() as i32
+            composite.serialize_value(&arg).unwrap();
+            composite.pos() as u32
         });
 
-        let ret_ofs = extern_transaction(mod_id, name, arg_ofs);
+        let ret_len = extern_transaction(mod_id, name, arg_len);
 
         self.with_arg_buf(|buf| {
-            let ret = unsafe { archived_value::<Ret>(buf, ret_ofs as usize) };
+            let slice = &buf[..ret_len as usize];
+            let ret = unsafe { archived_root::<Ret>(slice) };
             ret.deserialize(&mut Infallible).expect("Infallible")
         })
     }
@@ -150,10 +196,9 @@ impl<S> State<S> {
     /// to be called.
     pub fn caller(&self) -> ModuleId {
         self.with_arg_buf(|buf| {
-            let ret_ofs = unsafe { caller() };
-
+            let ret_len = unsafe { caller() };
             let ret =
-                unsafe { archived_value::<ModuleId>(buf, ret_ofs as usize) };
+                unsafe { archived_root::<ModuleId>(&buf[..ret_len as usize]) };
             ret.deserialize(&mut Infallible).expect("Infallible")
         })
     }
@@ -161,19 +206,19 @@ impl<S> State<S> {
     /// Emits an event with the given data.
     pub fn emit<D>(&self, data: D)
     where
-        for<'a> D: Serialize<Ser<'a>>,
+        for<'a> D: Serialize<StandardBufSerializer<'a>>,
     {
         self.with_arg_buf(|buf| {
-            let mut sbuf = [0u8; 16];
+            let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
             let scratch = BufferScratch::new(&mut sbuf);
             let ser = BufferSerializer::new(buf);
             let mut composite =
                 CompositeSerializer::new(ser, scratch, rkyv::Infallible);
 
-            let arg_ofs = composite.serialize_value(&data).unwrap() as i32;
-            let arg_len = composite.pos() as i32;
+            composite.serialize_value(&data).unwrap();
+            let arg_len = composite.pos() as u32;
 
-            unsafe { emit(arg_ofs, arg_len) }
+            unsafe { emit(arg_len) }
         });
     }
 

--- a/dallo/src/state.rs
+++ b/dallo/src/state.rs
@@ -184,9 +184,9 @@ impl<S> State<S> {
     /// Return the current height.
     pub fn height(&self) -> u64 {
         self.with_arg_buf(|buf| {
-            let ret_ofs = unsafe { height() };
+            let ret_len = unsafe { height() };
 
-            let ret = unsafe { archived_value::<u64>(buf, ret_ofs as usize) };
+            let ret = unsafe { archived_root::<u64>(&buf[..ret_len as usize]) };
             ret.deserialize(&mut Infallible).expect("Infallible")
         })
     }

--- a/dallo/src/types.rs
+++ b/dallo/src/types.rs
@@ -3,13 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
-
-use rkyv::{Archive, Deserialize, Serialize};
+use rkyv::{
+    ser::serializers::AllocSerializer, ser::Serializer, Archive, Deserialize,
+    Infallible, Serialize,
+};
 
 pub const MODULE_ID_BYTES: usize = 32;
 
 #[derive(
-    Debug,
     PartialEq,
     Eq,
     Archive,
@@ -49,5 +50,145 @@ impl ModuleId {
 impl From<[u8; 32]> for ModuleId {
     fn from(array: [u8; 32]) -> Self {
         ModuleId(array)
+    }
+}
+impl core::fmt::Debug for ModuleId {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if f.alternate() {
+            write!(f, "0x")?
+        }
+        for byte in self.0 {
+            write!(f, "{:02x}", &byte)?
+        }
+        Ok(())
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct RawQuery {
+    arg_len: u32,
+    data: alloc::vec::Vec<u8>,
+}
+
+impl RawQuery {
+    pub fn new<A>(name: &str, arg: A) -> Self
+    where
+        A: Serialize<AllocSerializer<64>>,
+    {
+        let mut ser = AllocSerializer::default();
+
+        ser.serialize_value(&arg)
+            .expect("We assume infallible serialization and allocation");
+
+        let arg_len = ser.pos() as u32;
+
+        let mut data = ser.into_serializer().into_inner().to_vec();
+
+        let name_as_bytes = name.as_bytes();
+
+        data.extend_from_slice(name_as_bytes);
+
+        RawQuery { arg_len, data }
+    }
+
+    pub fn name(&self) -> &str {
+        core::str::from_utf8(&self.data[self.arg_len as usize..])
+            .expect("always created from a valid &str")
+    }
+
+    pub fn arg_bytes(&self) -> &[u8] {
+        &self.data[..self.arg_len as usize]
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct RawTransaction {
+    arg_len: u32,
+    // TODO: use AlignedVec
+    data: alloc::vec::Vec<u8>,
+}
+
+impl RawTransaction {
+    pub fn new<A>(name: &str, arg: A) -> Self
+    where
+        A: Serialize<AllocSerializer<64>>,
+    {
+        let mut ser = AllocSerializer::default();
+
+        ser.serialize_value(&arg)
+            .expect("We assume infallible serialization and allocation");
+
+        let arg_len = ser.pos() as u32;
+
+        let mut data = ser.into_serializer().into_inner().to_vec();
+
+        data.extend_from_slice(name.as_bytes());
+
+        RawTransaction { arg_len, data }
+    }
+
+    pub fn name(&self) -> &str {
+        core::str::from_utf8(&self.data[self.arg_len as usize..])
+            .expect("always created from a valid &str")
+    }
+
+    pub fn arg_bytes(&self) -> &[u8] {
+        &self.data[..self.arg_len as usize]
+    }
+}
+
+#[derive(Archive, Serialize, Deserialize)]
+pub struct RawResult {
+    data: alloc::vec::Vec<u8>,
+}
+
+impl RawResult {
+    pub fn new(bytes: &[u8]) -> Self {
+        RawResult {
+            data: alloc::vec::Vec::from(bytes),
+        }
+    }
+
+    pub fn cast<D>(&self) -> D
+    where
+        D: Archive,
+        D::Archived: Deserialize<D, Infallible>,
+    {
+        // add bytecheck here.
+        let archived = unsafe { rkyv::archived_root::<D>(&self.data[..]) };
+        archived.deserialize(&mut Infallible).expect("Infallible")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn raw_query() {
+        let q = RawQuery::new("hello", 42u128);
+
+        assert_eq!(q.name(), "hello");
+        assert_eq!(
+            q.arg_bytes(),
+            [
+                0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            ]
+        );
+    }
+
+    #[test]
+    fn raw_transaction() {
+        let q = RawQuery::new("world", 666u128);
+
+        assert_eq!(q.name(), "world");
+        assert_eq!(
+            q.arg_bytes(),
+            [
+                0x9a, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            ]
+        );
     }
 }

--- a/dallo/src/types.rs
+++ b/dallo/src/types.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
+
 use rkyv::{
     ser::serializers::AllocSerializer, ser::Serializer, Archive, Deserialize,
     Infallible, Serialize,

--- a/hatchery/src/instance.rs
+++ b/hatchery/src/instance.rs
@@ -6,9 +6,11 @@
 
 use colored::*;
 
-use dallo::{ModuleId, Ser, MODULE_ID_BYTES, SCRATCH_BUF_BYTES};
+use dallo::{
+    ModuleId, StandardBufSerializer, MODULE_ID_BYTES, SCRATCH_BUF_BYTES,
+};
 use rkyv::{
-    archived_value,
+    archived_root,
     ser::serializers::{BufferScratch, BufferSerializer, CompositeSerializer},
     ser::Serializer,
     Archive, Deserialize, Infallible, Serialize,
@@ -27,7 +29,7 @@ pub struct Instance {
     world: World,
     mem_handler: MemHandler,
     arg_buf_ofs: i32,
-    arg_buf_len: i32,
+    arg_buf_len: u32,
     heap_base: i32,
     self_id_ofs: i32,
     snapshot_id: Option<SnapshotId>,
@@ -41,7 +43,7 @@ impl Instance {
         world: World,
         mem_handler: MemHandler,
         arg_buf_ofs: i32,
-        arg_buf_len: i32,
+        arg_buf_len: u32,
         heap_base: i32,
         self_id_ofs: i32,
     ) -> Self {
@@ -64,27 +66,26 @@ impl Instance {
         arg: Arg,
     ) -> Result<Ret, Error>
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>>,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
-        let ret_pos = {
-            let arg_ofs = self.write_to_arg_buffer(arg)?;
-
-            self.perform_query(name, arg_ofs)?
+        let ret_len = {
+            let arg_len = self.write_to_arg_buffer(arg)?;
+            self.perform_query(name, arg_len)?
         };
 
-        self.read_from_arg_buffer(ret_pos)
+        self.read_from_arg_buffer(ret_len)
     }
 
     pub(crate) fn perform_query(
         &self,
         name: &str,
-        arg_ofs: i32,
-    ) -> Result<i32, Error> {
-        let fun: NativeFunc<i32, i32> =
+        arg_len: u32,
+    ) -> Result<u32, Error> {
+        let fun: NativeFunc<u32, u32> =
             self.instance.exports.get_native_function(name)?;
-        Ok(fun.call(arg_ofs as i32)?)
+        Ok(fun.call(arg_len)?)
     }
 
     pub(crate) fn transact<Arg, Ret>(
@@ -93,27 +94,27 @@ impl Instance {
         arg: Arg,
     ) -> Result<Ret, Error>
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>> + core::fmt::Debug,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
-        let ret_pos = {
+        println!("arg {:?}", arg);
+        let ret_len = {
             let arg_ofs = self.write_to_arg_buffer(arg)?;
-
             self.perform_transaction(name, arg_ofs)?
         };
 
-        self.read_from_arg_buffer(ret_pos)
+        self.read_from_arg_buffer(ret_len)
     }
 
     pub(crate) fn perform_transaction(
         &self,
         name: &str,
-        arg_ofs: i32,
-    ) -> Result<i32, Error> {
-        let fun: NativeFunc<i32, i32> =
+        arg_len: u32,
+    ) -> Result<u32, Error> {
+        let fun: NativeFunc<u32, u32> =
             self.instance.exports.get_native_function(name)?;
-        Ok(fun.call(arg_ofs as i32)?)
+        Ok(fun.call(arg_len)?)
     }
 
     pub(crate) fn with_memory<F, R>(&self, f: F) -> R
@@ -149,38 +150,40 @@ impl Instance {
             );
 
         let ofs = self.self_id_ofs as usize;
-        let end = ofs + MODULE_ID_BYTES;
 
-        let callee_buf = unsafe { mem.data_unchecked_mut() };
-        let callee_buf = &mut callee_buf[ofs..end];
+        let memory = unsafe { mem.data_unchecked_mut() };
+        let self_id_buf = &mut memory[ofs..][..MODULE_ID_BYTES];
 
-        callee_buf.copy_from_slice(module_id.as_bytes());
+        self_id_buf.copy_from_slice(module_id.as_bytes());
     }
 
-    pub(crate) fn write_to_arg_buffer<T>(&self, value: T) -> Result<i32, Error>
+    pub(crate) fn write_to_arg_buffer<T>(&self, value: T) -> Result<u32, Error>
     where
-        T: for<'a> Serialize<Ser<'a>>,
+        T: for<'a> Serialize<StandardBufSerializer<'a>>,
     {
         self.with_arg_buffer(|abuf| {
             let mut sbuf = [0u8; SCRATCH_BUF_BYTES];
             let scratch = BufferScratch::new(&mut sbuf);
             let ser = BufferSerializer::new(abuf);
-            let mut composite =
+            let mut ser =
                 CompositeSerializer::new(ser, scratch, rkyv::Infallible);
 
-            Ok(composite.serialize_value(&value)? as i32)
+            ser.serialize_value(&value)?;
+
+            Ok(ser.pos() as u32)
         })
     }
 
-    fn read_from_arg_buffer<T>(&self, arg_ofs: i32) -> Result<T, Error>
+    fn read_from_arg_buffer<T>(&self, arg_len: u32) -> Result<T, Error>
     where
         T: Archive,
         T::Archived: Deserialize<T, Infallible>,
     {
         // TODO use bytecheck here
+        println!("read {:?} len {:?}", core::any::type_name::<T>(), arg_len);
         Ok(self.with_arg_buffer(|abuf| {
-            let ta: &T::Archived =
-                unsafe { archived_value::<T>(abuf, arg_ofs as usize) };
+            let slice = &abuf[..arg_len as usize];
+            let ta: &T::Archived = unsafe { archived_root::<T>(slice) };
             ta.deserialize(&mut Infallible).unwrap()
         }))
     }

--- a/hatchery/src/instance.rs
+++ b/hatchery/src/instance.rs
@@ -98,7 +98,6 @@ impl Instance {
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
-        println!("arg {:?}", arg);
         let ret_len = {
             let arg_ofs = self.write_to_arg_buffer(arg)?;
             self.perform_transaction(name, arg_ofs)?
@@ -180,7 +179,6 @@ impl Instance {
         T::Archived: Deserialize<T, Infallible>,
     {
         // TODO use bytecheck here
-        println!("read {:?} len {:?}", core::any::type_name::<T>(), arg_len);
         Ok(self.with_arg_buffer(|abuf| {
             let slice = &abuf[..arg_len as usize];
             let ta: &T::Archived = unsafe { archived_root::<T>(slice) };

--- a/hatchery/src/memory.rs
+++ b/hatchery/src/memory.rs
@@ -22,7 +22,6 @@ impl MemHandler {
         self.align_to(align);
         let ofs = self.heap_base;
         self.heap_base += size;
-        println!("allocating {} bytes at {:08x}", size, ofs);
         ofs
     }
 }

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -323,7 +323,7 @@ impl World {
         Ok(ret_len)
     }
 
-    fn perform_height(&self, instance: &Instance) -> Result<i32, Error> {
+    fn perform_height(&self, instance: &Instance) -> Result<u32, Error> {
         let guard = self.0.lock();
         let w = unsafe { &*guard.get() };
 
@@ -440,7 +440,7 @@ fn host_transact(
         .expect("TODO: error handling")
 }
 
-fn host_height(env: &Env) -> i32 {
+fn host_height(env: &Env) -> u32 {
     let instance = env.inner();
     instance
         .world()

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -94,11 +94,6 @@ impl World {
             let snapshot = Snapshot::new(&memory_path)?;
             environment.inner_mut().set_snapshot_id(snapshot.id());
             snapshot.save(&memory_path)?;
-            println!(
-                "persisted state of module: {:?} to file: {:?}",
-                module_id_to_name(*module_id),
-                snapshot.path()
-            );
         }
         Ok(())
     }
@@ -267,8 +262,6 @@ impl World {
 
         w.call_stack.push(callee);
 
-        println!("perform query\n{:?}\n{:?}", caller, callee);
-
         let caller = w.get(&caller).expect("oh no").inner();
         let callee = w.get(&callee).expect("no oh").inner();
 
@@ -305,8 +298,6 @@ impl World {
         let w = unsafe { &mut *guard.get() };
 
         w.call_stack.push(callee);
-
-        println!("perform transaction\n{:?}\n{:?}", caller, callee);
 
         let caller = w.get(&caller).expect("oh no").inner();
         let callee = w.get(&callee).expect("no oh").inner();
@@ -350,8 +341,6 @@ impl World {
         let guard = self.0.lock();
         let w = unsafe { &*guard.get() };
         let caller = w.call_stack.caller();
-
-        println!("perform_caller id {:?}", caller);
 
         instance.write_to_arg_buffer(caller)
     }

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -16,9 +16,9 @@ use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use dallo::{ModuleId, Ser, MODULE_ID_BYTES};
+use dallo::{ModuleId, StandardBufSerializer, MODULE_ID_BYTES};
 use parking_lot::ReentrantMutex;
-use rkyv::{archived_value, Archive, Deserialize, Infallible, Serialize};
+use rkyv::{archived_root, Archive, Deserialize, Infallible, Serialize};
 use stack::CallStack;
 use tempfile::tempdir;
 use wasmer::{imports, Exports, Function, Val};
@@ -167,8 +167,8 @@ impl World {
         let mem = instance.exports.get_memory("memory")?;
         let data =
             &unsafe { mem.data_unchecked() }[arg_buf_len_pos as usize..][..4];
-
-        let arg_buf_len: i32 = unsafe { archived_value::<i32>(data, 0) }
+        let slice = &data[..mem::size_of::<<u32 as Archive>::Archived>()];
+        let arg_buf_len: u32 = unsafe { archived_root::<u32>(slice) }
             .deserialize(&mut Infallible)
             .expect("infallible");
 
@@ -200,7 +200,7 @@ impl World {
         arg: Arg,
     ) -> Result<Receipt<Ret>, Error>
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>>,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
@@ -227,7 +227,7 @@ impl World {
         arg: Arg,
     ) -> Result<Receipt<Ret>, Error>
     where
-        Arg: for<'a> Serialize<Ser<'a>>,
+        Arg: for<'a> Serialize<StandardBufSerializer<'a>> + core::fmt::Debug,
         Ret: Archive,
         Ret::Archived: Deserialize<Ret, Infallible>,
     {
@@ -260,12 +260,14 @@ impl World {
         name: &str,
         caller: ModuleId,
         callee: ModuleId,
-        arg_ofs: i32,
-    ) -> Result<i32, Error> {
+        arg_len: u32,
+    ) -> Result<u32, Error> {
         let guard = self.0.lock();
         let w = unsafe { &mut *guard.get() };
 
         w.call_stack.push(callee);
+
+        println!("perform query\n{:?}\n{:?}", caller, callee);
 
         let caller = w.get(&caller).expect("oh no").inner();
         let callee = w.get(&callee).expect("no oh").inner();
@@ -279,7 +281,7 @@ impl World {
             })
         });
 
-        let ret_ofs = callee.perform_query(name, arg_ofs)?;
+        let ret_ofs = callee.perform_query(name, arg_len)?;
 
         callee.with_arg_buffer(|buf_callee| {
             caller.with_arg_buffer(|buf_caller| {
@@ -297,12 +299,14 @@ impl World {
         name: &str,
         caller: ModuleId,
         callee: ModuleId,
-        arg_ofs: i32,
-    ) -> Result<i32, Error> {
+        arg_len: u32,
+    ) -> Result<u32, Error> {
         let guard = self.0.lock();
         let w = unsafe { &mut *guard.get() };
 
         w.call_stack.push(callee);
+
+        println!("perform transaction\n{:?}\n{:?}", caller, callee);
 
         let caller = w.get(&caller).expect("oh no").inner();
         let callee = w.get(&callee).expect("no oh").inner();
@@ -314,7 +318,7 @@ impl World {
             })
         });
 
-        let ret_ofs = callee.perform_transaction(name, arg_ofs)?;
+        let ret_len = callee.perform_transaction(name, arg_len)?;
 
         callee.with_arg_buffer(|buf_callee| {
             caller.with_arg_buffer(|buf_caller| {
@@ -325,7 +329,7 @@ impl World {
 
         w.call_stack.pop();
 
-        Ok(ret_ofs)
+        Ok(ret_len)
     }
 
     fn perform_height(&self, instance: &Instance) -> Result<i32, Error> {
@@ -342,11 +346,12 @@ impl World {
         w.events.push(Event::new(module_id, data));
     }
 
-    fn perform_caller(&self, instance: &Instance) -> Result<i32, Error> {
+    fn perform_caller(&self, instance: &Instance) -> Result<u32, Error> {
         let guard = self.0.lock();
         let w = unsafe { &*guard.get() };
+        let caller = w.call_stack.caller();
 
-        let caller = w.call_stack.caller().unwrap_or(ModuleId::uninitialized());
+        println!("perform_caller id {:?}", caller);
 
         instance.write_to_arg_buffer(caller)
     }
@@ -386,9 +391,9 @@ fn host_query(
     env: &Env,
     module_id_adr: i32,
     method_name_adr: i32,
-    method_name_len: i32,
-    arg_ofs: i32,
-) -> i32 {
+    method_name_len: u32,
+    arg_len: u32,
+) -> u32 {
     let module_id_adr = module_id_adr as usize;
     let method_name_adr = method_name_adr as usize;
     let method_name_len = method_name_len as usize;
@@ -410,7 +415,7 @@ fn host_query(
 
     instance
         .world()
-        .perform_query(&name, instance.id(), mod_id, arg_ofs)
+        .perform_query(&name, instance.id(), mod_id, arg_len)
         .expect("TODO: error handling")
 }
 
@@ -418,9 +423,9 @@ fn host_transact(
     env: &Env,
     module_id_adr: i32,
     method_name_adr: i32,
-    method_name_len: i32,
-    arg_ofs: i32,
-) -> i32 {
+    method_name_len: u32,
+    arg_len: u32,
+) -> u32 {
     let module_id_adr = module_id_adr as usize;
     let method_name_adr = method_name_adr as usize;
     let method_name_len = method_name_len as usize;
@@ -442,7 +447,7 @@ fn host_transact(
 
     instance
         .world()
-        .perform_transaction(&name, instance.id(), mod_id, arg_ofs)
+        .perform_transaction(&name, instance.id(), mod_id, arg_len)
         .expect("TODO: error handling")
 }
 
@@ -454,19 +459,18 @@ fn host_height(env: &Env) -> i32 {
         .expect("TODO: error handling")
 }
 
-fn host_emit(env: &Env, arg_ofs: i32, arg_len: i32) {
+fn host_emit(env: &Env, arg_len: u32) {
     let instance = env.inner();
     let module_id = instance.id();
 
-    let arg_ofs = arg_ofs as usize;
     let arg_len = arg_len as usize;
 
-    let data = instance.with_arg_buffer(|buf| buf[arg_ofs..arg_len].to_vec());
+    let data = instance.with_arg_buffer(|buf| buf[..arg_len].to_vec());
 
     instance.world().perform_emit(module_id, data);
 }
 
-fn host_caller(env: &Env) -> i32 {
+fn host_caller(env: &Env) -> u32 {
     let instance = env.inner();
     instance
         .world()

--- a/hatchery/src/world/event.rs
+++ b/hatchery/src/world/event.rs
@@ -29,6 +29,11 @@ impl<T> Receipt<T> {
     pub fn events(&self) -> &[Event] {
         &self.events
     }
+
+    /// Convert into result
+    pub fn into_inner(self) -> T {
+        self.ret
+    }
 }
 
 impl<T> Deref for Receipt<T> {

--- a/hatchery/src/world/stack.rs
+++ b/hatchery/src/world/stack.rs
@@ -37,16 +37,14 @@ impl CallStack {
         }
     }
 
-    /// Return the `caller` of the currently running contract, if it is not the
-    /// first call. Otherwise return `None`.
-    pub fn caller(&self) -> Option<ModuleId> {
+    /// Return the `caller` of the currently running contract, may be
+    /// uninitialized
+    pub fn caller(&self) -> ModuleId {
         let len = self.inner.len();
-
         if len > 1 {
-            let module_id = self.inner[len - 2].module_id;
-            return Some(module_id);
+            self.inner[len - 2].module_id
+        } else {
+            ModuleId::uninitialized()
         }
-
-        None
     }
 }

--- a/hatchery/tests/boxen.rs
+++ b/hatchery/tests/boxen.rs
@@ -14,13 +14,13 @@ pub fn box_set_get() -> Result<(), Error> {
 
     let id = world.deploy(module_bytecode!("box"))?;
 
-    let value: Receipt<Option<i32>> = world.query(id, "get", ())?;
+    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
 
     assert_eq!(*value, None);
 
-    let _: Receipt<()> = world.transact(id, "set", 0x11)?;
+    world.transact::<i16, ()>(id, "set", 0x11)?;
 
-    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    let value = world.query::<_, Option<i16>>(id, "get", ())?;
 
     assert_eq!(*value, Some(0x11));
 
@@ -37,7 +37,7 @@ pub fn box_set_store_restore_get() -> Result<(), Error> {
 
         first_id = first_world.deploy(module_bytecode!("box"))?;
 
-        let _: Receipt<()> = first_world.transact(first_id, "set", 0x23)?;
+        first_world.transact::<i16, ()>(first_id, "set", 0x23)?;
 
         first_world.storage_path().clone_into(&mut storage_path);
     }
@@ -48,8 +48,7 @@ pub fn box_set_store_restore_get() -> Result<(), Error> {
 
     assert_eq!(first_id, second_id);
 
-    let value: Receipt<Option<i16>> =
-        second_world.query(second_id, "get", ())?;
+    let value = second_world.query::<_, Option<i16>>(second_id, "get", ())?;
 
     assert_eq!(*value, Some(0x23));
 
@@ -61,14 +60,16 @@ pub fn world_persist_restore() -> Result<(), Error> {
     let mut world = World::ephemeral()?;
     let id = world.deploy(module_bytecode!("box"))?;
 
-    let _: Receipt<()> = world.transact(id, "set", 17)?;
-    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    world.transact::<i16, ()>(id, "set", 17)?;
+
+    let value = world.query::<_, Option<i16>>(id, "get", ())?;
+
     assert_eq!(*value, Some(17));
 
     world.persist()?;
 
-    let _: Receipt<()> = world.transact(id, "set", 18)?;
-    let value: Receipt<Option<i16>> = world.query(id, "get", ())?;
+    world.transact::<i16, ()>(id, "set", 18)?;
+    let value = world.query::<_, Option<i16>>(id, "get", ())?;
     assert_eq!(*value, Some(18));
 
     world.restore()?;

--- a/hatchery/tests/callcenter.rs
+++ b/hatchery/tests/callcenter.rs
@@ -38,14 +38,10 @@ pub fn world_center_counter_direct() -> Result<(), Error> {
 
     let center_id = world.deploy(module_bytecode!("callcenter"))?;
 
-    println!("urf");
-
     // read value through callcenter
     let value: Receipt<i64> =
         world.query(center_id, "query_counter", counter_id)?;
     assert_eq!(*value, 0xfc);
-
-    println!("gruff");
 
     // increment through call center
     let _: Receipt<()> =
@@ -71,8 +67,6 @@ pub fn world_center_counter_delegated() -> Result<(), Error> {
     let center_id = world.deploy(module_bytecode!("callcenter"))?;
 
     let rq = RawQuery::new("read_value", ());
-
-    println!("raw query {:?}", rq);
 
     let res: Receipt<RawQuery> =
         world.query(center_id, "query_passthrough", rq.clone())?;

--- a/hatchery/tests/counter.rs
+++ b/hatchery/tests/counter.rs
@@ -12,7 +12,7 @@ pub fn counter_trivial() -> Result<(), Error> {
 
     let id = world.deploy(module_bytecode!("counter"))?;
 
-    let value: Receipt<i32> = world.query(id, "read_value", ())?;
+    let value: Receipt<i64> = world.query(id, "read_value", ())?;
 
     assert_eq!(*value, 0xfc);
 
@@ -27,12 +27,12 @@ pub fn counter_increment() -> Result<(), Error> {
 
     let _: Receipt<()> = world.transact(id, "increment", ())?;
 
-    let value: Receipt<i32> = world.query(id, "read_value", ())?;
+    let value: Receipt<i64> = world.query(id, "read_value", ())?;
     assert_eq!(*value, 0xfd);
 
     let _: Receipt<()> = world.transact(id, "increment", ())?;
 
-    let value: Receipt<i32> = world.query(id, "read_value", ())?;
+    let value: Receipt<i64> = world.query(id, "read_value", ())?;
     assert_eq!(*value, 0xfe);
 
     Ok(())
@@ -44,11 +44,11 @@ pub fn counter_mogrify() -> Result<(), Error> {
 
     let id = world.deploy(module_bytecode!("counter"))?;
 
-    let value: Receipt<i32> = world.transact(id, "mogrify", 32)?;
+    let value = world.transact::<i64, i64>(id, "mogrify", 32)?;
 
     assert_eq!(*value, 0xfc);
 
-    let value: Receipt<i32> = world.query(id, "read_value", ())?;
+    let value: Receipt<i64> = world.query(id, "read_value", ())?;
     assert_eq!(*value, 0xfc - 32);
 
     Ok(())

--- a/hatchery/tests/stacked.rs
+++ b/hatchery/tests/stacked.rs
@@ -16,7 +16,7 @@ pub fn push_pop() -> Result<(), Error> {
 
     let _: Receipt<()> = world.transact(id, "push", val)?;
 
-    let len: Receipt<i32> = world.query(id, "len", ())?;
+    let len: Receipt<u32> = world.query(id, "len", ())?;
     assert_eq!(*len, 1);
 
     let popped: Receipt<Option<i32>> = world.transact(id, "pop", ())?;

--- a/hatchery/tests/vector.rs
+++ b/hatchery/tests/vector.rs
@@ -15,7 +15,7 @@ pub fn vector_push_pop() -> Result<(), Error> {
     const N: usize = 128;
 
     for i in 0..N {
-        let _: Receipt<()> = world.transact(id, "push", i)?;
+        world.transact::<_, ()>(id, "push", i as i16)?;
     }
 
     for i in 0..N {

--- a/modules/box/src/lib.rs
+++ b/modules/box/src/lib.rs
@@ -27,7 +27,7 @@ const ARGBUF_LEN: usize = 8;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -49,11 +49,11 @@ impl Boxen {
 }
 
 #[no_mangle]
-unsafe fn set(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |to| STATE.set(to))
+unsafe fn set(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |to| STATE.set(to))
 }
 
 #[no_mangle]
-unsafe fn get(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |_: ()| STATE.get())
+unsafe fn get(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |_: ()| STATE.get())
 }

--- a/modules/counter/src/lib.rs
+++ b/modules/counter/src/lib.rs
@@ -23,7 +23,7 @@ const ARGBUF_LEN: usize = 64;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -32,7 +32,7 @@ static mut STATE: State<Counter> =
     unsafe { State::new(Counter { value: 0xfc }, &mut A) };
 
 impl Counter {
-    pub fn read_value(self: &State<Counter>) -> i64 {
+    pub fn read_value(&self) -> i64 {
         self.value
     }
 
@@ -43,7 +43,7 @@ impl Counter {
         self.value = value;
     }
 
-    pub fn mogrify(self: &mut State<Counter>, x: i64) -> i64 {
+    pub fn mogrify(&mut self, x: i64) -> i64 {
         let old = self.read_value();
         self.value -= x;
         old
@@ -51,16 +51,16 @@ impl Counter {
 }
 
 #[no_mangle]
-unsafe fn read_value(a: i32) -> i32 {
-    dallo::wrap_query(STATE.buffer(), a, |_: ()| STATE.read_value())
+unsafe fn read_value(arg_len: u32) -> u32 {
+    dallo::wrap_query(STATE.buffer(), arg_len, |_: ()| STATE.read_value())
 }
 
 #[no_mangle]
-unsafe fn increment(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |_: ()| STATE.increment())
+unsafe fn increment(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |_: ()| STATE.increment())
 }
 
 #[no_mangle]
-unsafe fn mogrify(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |by| STATE.mogrify(by))
+unsafe fn mogrify(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |by| STATE.mogrify(by))
 }

--- a/modules/eventer/src/lib.rs
+++ b/modules/eventer/src/lib.rs
@@ -21,7 +21,7 @@ const ARGBUF_LEN: usize = 64;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -37,6 +37,6 @@ impl Eventer {
 }
 
 #[no_mangle]
-unsafe fn emit_events(a: i32) -> i32 {
-    dallo::wrap_query(STATE.buffer(), a, |num| STATE.emit_num(num))
+unsafe fn emit_events(arg_len: u32) -> u32 {
+    dallo::wrap_query(STATE.buffer(), arg_len, |num| STATE.emit_num(num))
 }

--- a/modules/everest/src/lib.rs
+++ b/modules/everest/src/lib.rs
@@ -21,7 +21,7 @@ const ARGBUF_LEN: usize = 64;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -35,6 +35,6 @@ impl Height {
 }
 
 #[no_mangle]
-unsafe fn get_height(a: i32) -> i32 {
+unsafe fn get_height(a: u32) -> u32 {
     dallo::wrap_query(STATE.buffer(), a, |_: ()| STATE.get_height())
 }

--- a/modules/fibonacci/src/lib.rs
+++ b/modules/fibonacci/src/lib.rs
@@ -21,7 +21,7 @@ const ARGBUF_LEN: usize = 64;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -31,7 +31,6 @@ static mut STATE: State<Fibonacci> = State::new(Fibonacci, unsafe { &mut A });
 
 impl Fibonacci {
     fn nth(n: u32) -> u64 {
-        dallo::snap();
         match n {
             0 | 1 => 1,
             n => Self::nth(n - 1) + Self::nth(n - 2),
@@ -40,6 +39,6 @@ impl Fibonacci {
 }
 
 #[no_mangle]
-unsafe fn nth(a: i32) -> i32 {
-    dallo::wrap_query(STATE.buffer(), a, |n: u32| Fibonacci::nth(n))
+unsafe fn nth(arg_len: u32) -> u32 {
+    dallo::wrap_query(STATE.buffer(), arg_len, |n: u32| Fibonacci::nth(n))
 }

--- a/modules/self_snapshot/src/lib.rs
+++ b/modules/self_snapshot/src/lib.rs
@@ -21,7 +21,7 @@ const ARGBUF_LEN: usize = 64;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -80,25 +80,27 @@ impl SelfSnapshot {
 }
 
 #[no_mangle]
-unsafe fn crossover(a: i32) -> i32 {
-    dallo::wrap_query(STATE.buffer(), a, |_: ()| STATE.crossover())
+unsafe fn crossover(arg_len: u32) -> u32 {
+    dallo::wrap_query(STATE.buffer(), arg_len, |_: ()| STATE.crossover())
 }
 
 #[no_mangle]
-unsafe fn set_crossover(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |arg: i32| {
+unsafe fn set_crossover(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |arg: i32| {
         STATE.set_crossover(arg)
     })
 }
 
 #[no_mangle]
-unsafe fn self_call_test_a(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |arg: i32| {
+unsafe fn self_call_test_a(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |arg: i32| {
         STATE.self_call_test_a(arg)
     })
 }
 
 #[no_mangle]
-unsafe fn self_call_test_b(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |_: ()| STATE.self_call_test_b())
+unsafe fn self_call_test_b(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |_: ()| {
+        STATE.self_call_test_b()
+    })
 }

--- a/modules/stack/src/lib.rs
+++ b/modules/stack/src/lib.rs
@@ -26,7 +26,7 @@ const ARGBUF_LEN: usize = 8;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -47,22 +47,24 @@ impl Stack {
         self.inner.pop()
     }
 
-    pub fn len(&self) -> i32 {
-        *Cardinality::from_child(&self.inner) as i32
+    pub fn len(&self) -> u32 {
+        *Cardinality::from_child(&self.inner) as u32
     }
 }
 
 #[no_mangle]
-unsafe fn push(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |elem: i32| STATE.push(elem))
+unsafe fn push(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |elem: i32| {
+        STATE.push(elem)
+    })
 }
 
 #[no_mangle]
-unsafe fn pop(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |_arg: ()| STATE.pop())
+unsafe fn pop(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |_arg: ()| STATE.pop())
 }
 
 #[no_mangle]
-unsafe fn len(a: i32) -> i32 {
-    dallo::wrap_query(STATE.buffer(), a, |_arg: ()| STATE.len())
+unsafe fn len(arg_len: u32) -> u32 {
+    dallo::wrap_query(STATE.buffer(), arg_len, |_arg: ()| STATE.len())
 }

--- a/modules/vector/src/lib.rs
+++ b/modules/vector/src/lib.rs
@@ -24,7 +24,7 @@ const ARGBUF_LEN: usize = 8;
 #[no_mangle]
 static mut A: [u64; ARGBUF_LEN / 8] = [0; ARGBUF_LEN / 8];
 #[no_mangle]
-static AL: i32 = ARGBUF_LEN as i32;
+static AL: u32 = ARGBUF_LEN as u32;
 
 #[no_mangle]
 static SELF_ID: ModuleId = ModuleId::uninitialized();
@@ -43,11 +43,11 @@ impl Vector {
 }
 
 #[no_mangle]
-unsafe fn push(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |arg| STATE.push(arg))
+unsafe fn push(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |arg| STATE.push(arg))
 }
 
 #[no_mangle]
-unsafe fn pop(a: i32) -> i32 {
-    dallo::wrap_transaction(STATE.buffer(), a, |_arg: ()| STATE.pop())
+unsafe fn pop(arg_len: u32) -> u32 {
+    dallo::wrap_transaction(STATE.buffer(), arg_len, |_arg: ()| STATE.pop())
 }


### PR DESCRIPTION
Change lengths to use unsigned `u32`s everywhere
Change argument and return passing to use the serialized length of the value, rather than the encoded position.

fixes #30 