### PR TITLE
Add `spent` and `limit` host calls

### DIFF
--- a/dallo/src/lib.rs
+++ b/dallo/src/lib.rs
@@ -14,7 +14,7 @@ mod snap;
 pub use snap::snap;
 
 mod state;
-pub use state::{caller, emit, height, query, query_raw, spent, State};
+pub use state::{caller, emit, height, limit, query, query_raw, spent, State};
 
 mod helpers;
 pub use helpers::*;

--- a/dallo/src/lib.rs
+++ b/dallo/src/lib.rs
@@ -14,7 +14,7 @@ mod snap;
 pub use snap::snap;
 
 mod state;
-pub use state::{caller, emit, height, query, query_raw, State};
+pub use state::{caller, emit, height, query, query_raw, spent, State};
 
 mod helpers;
 pub use helpers::*;

--- a/dallo/src/state.rs
+++ b/dallo/src/state.rs
@@ -54,9 +54,10 @@ mod ext {
             arg_len: u32,
         ) -> u32;
 
-        pub(crate) fn height() -> i32;
+        pub(crate) fn height() -> u32;
         pub(crate) fn caller() -> u32;
         pub(crate) fn emit(arg_len: u32);
+        pub(crate) fn spent() -> u32;
     }
 }
 
@@ -179,6 +180,15 @@ where
 
         unsafe { ext::emit(arg_len) }
     });
+}
+
+pub fn spent() -> u64 {
+    with_arg_buf(|buf| {
+        let ret_len = unsafe { ext::spent() };
+
+        let ret = check_archived_root::<u64>(&buf[..ret_len as usize]).unwrap();
+        ret.deserialize(&mut Infallible).expect("Infallible")
+    })
 }
 
 impl<S> State<S> {

--- a/dallo/src/state.rs
+++ b/dallo/src/state.rs
@@ -57,6 +57,7 @@ mod ext {
         pub(crate) fn height() -> u32;
         pub(crate) fn caller() -> u32;
         pub(crate) fn emit(arg_len: u32);
+        pub(crate) fn limit() -> u32;
         pub(crate) fn spent() -> u32;
     }
 }
@@ -180,6 +181,15 @@ where
 
         unsafe { ext::emit(arg_len) }
     });
+}
+
+pub fn limit() -> u64 {
+    with_arg_buf(|buf| {
+        let ret_len = unsafe { ext::limit() };
+
+        let ret = check_archived_root::<u64>(&buf[..ret_len as usize]).unwrap();
+        ret.deserialize(&mut Infallible).expect("Infallible")
+    })
 }
 
 pub fn spent() -> u64 {

--- a/hatchery/src/world.rs
+++ b/hatchery/src/world.rs
@@ -154,6 +154,7 @@ impl World {
                 "height" => Function::new_native_with_env(&store, env.clone(), host_height),
                 "emit" => Function::new_native_with_env(&store, env.clone(), host_emit),
                 "caller" => Function::new_native_with_env(&store, env.clone(), host_caller),
+                "limit" => Function::new_native_with_env(&store, env.clone(), host_limit),
                 "spent" => Function::new_native_with_env(&store, env.clone(), host_spent),
             }
         };
@@ -369,6 +370,14 @@ impl World {
         w.events.push(Event::new(module_id, data));
     }
 
+    fn perform_limit(&self, instance: &Instance) -> Result<u32, Error> {
+        let guard = self.0.lock();
+        let w = unsafe { &*guard.get() };
+
+        let limit = w.call_stack.limit();
+        instance.write_to_arg_buffer(limit)
+    }
+
     fn perform_spent(&self, instance: &Instance) -> Result<u32, Error> {
         let guard = self.0.lock();
         let w = unsafe { &*guard.get() };
@@ -506,6 +515,14 @@ fn host_spent(env: &Env) -> u32 {
     instance
         .world()
         .perform_spent(instance)
+        .expect("TODO: error handling")
+}
+
+fn host_limit(env: &Env) -> u32 {
+    let instance = env.inner();
+    instance
+        .world()
+        .perform_limit(instance)
         .expect("TODO: error handling")
 }
 

--- a/hatchery/src/world/event.rs
+++ b/hatchery/src/world/event.rs
@@ -13,16 +13,12 @@ use std::ops::Deref;
 pub struct Receipt<T> {
     ret: T,
     events: Vec<Event>,
-    points_used: u64,
+    spent: u64,
 }
 
 impl<T> Receipt<T> {
-    pub(crate) fn new(ret: T, events: Vec<Event>, points_used: u64) -> Self {
-        Self {
-            ret,
-            events,
-            points_used,
-        }
+    pub(crate) fn new(ret: T, events: Vec<Event>, spent: u64) -> Self {
+        Self { ret, events, spent }
     }
 
     /// Get the return of the query or transaction.
@@ -35,9 +31,9 @@ impl<T> Receipt<T> {
         &self.events
     }
 
-    /// Return the points used by the call.
-    pub fn points_used(&self) -> u64 {
-        self.points_used
+    /// Return the points spent by the call.
+    pub fn spent(&self) -> u64 {
+        self.spent
     }
 
     /// Convert into result

--- a/hatchery/src/world/stack.rs
+++ b/hatchery/src/world/stack.rs
@@ -9,6 +9,7 @@ use dallo::ModuleId;
 #[derive(Debug)]
 struct CallData {
     module_id: ModuleId,
+    limit: u64,
 }
 
 #[derive(Debug, Default)]
@@ -18,16 +19,16 @@ pub struct CallStack {
 
 impl CallStack {
     /// Create a new call stack, with the initiating call being made to
-    /// `module_id`.
-    pub fn new(module_id: ModuleId) -> Self {
+    /// `module_id` with the given `limit`.
+    pub fn new(module_id: ModuleId, limit: u64) -> Self {
         Self {
-            inner: vec![CallData { module_id }],
+            inner: vec![CallData { module_id, limit }],
         }
     }
 
     /// Push a call onto the call stack.
-    pub fn push(&mut self, module_id: ModuleId) {
-        self.inner.push(CallData { module_id })
+    pub fn push(&mut self, module_id: ModuleId, limit: u64) {
+        self.inner.push(CallData { module_id, limit })
     }
 
     /// Pop a call from the call stack.
@@ -46,5 +47,10 @@ impl CallStack {
         } else {
             ModuleId::uninitialized()
         }
+    }
+
+    /// Return the point limit given to the currently executing contract
+    pub fn limit(&self) -> u64 {
+        self.inner[self.inner.len() - 1].limit
     }
 }

--- a/hatchery/tests/points.rs
+++ b/hatchery/tests/points.rs
@@ -18,7 +18,7 @@ pub fn points_get_used() -> Result<(), Error> {
     let receipt_center: Receipt<i64> =
         world.query(center_id, "query_counter", counter_id)?;
 
-    assert!(receipt_counter.points_used() < receipt_center.points_used());
+    assert!(receipt_counter.spent() < receipt_center.spent());
 
     Ok(())
 }
@@ -65,7 +65,7 @@ pub fn limit_and_spent() -> Result<(), Error> {
     println!("spent after : {}\n", spent_after);
 
     println!("=== Actual cost  ===");
-    println!("actual cost : {}", receipt_spender.points_used());
+    println!("actual cost : {}", receipt_spender.spent());
 
     Ok(())
 }

--- a/hatchery/tests/points.rs
+++ b/hatchery/tests/points.rs
@@ -38,3 +38,34 @@ pub fn fails_with_out_of_points() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+pub fn limit_and_spent() -> Result<(), Error> {
+    let mut world = World::ephemeral()?;
+
+    const LIMIT: u64 = 10000;
+
+    world.set_point_limit(LIMIT);
+    let spender_id = world.deploy(module_bytecode!("spender"))?;
+
+    let receipt_spender: Receipt<(u64, u64, u64, u64, u64)> =
+        world.query(spender_id, "get_limit_and_spent", ())?;
+
+    let (limit, spent_before, spent_after, called_limit, called_after) =
+        *receipt_spender;
+
+    assert_eq!(limit, LIMIT, "should be the initial limit");
+
+    println!("=== Spender costs ===");
+
+    println!("limit       : {}", limit);
+    println!("spent before: {}", spent_before);
+    println!("called limit: {}", called_limit);
+    println!("called after: {}", called_after);
+    println!("spent after : {}\n", spent_after);
+
+    println!("=== Actual cost  ===");
+    println!("actual cost : {}", receipt_spender.points_used());
+
+    Ok(())
+}

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -8,5 +8,6 @@ members = [
     "everest",
     "fibonacci",
     "stack",
+    "spender",
     "vector",
 ]

--- a/modules/spender/Cargo.toml
+++ b/modules/spender/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spender"
+version = "0.1.0"
+authors = [
+    "Eduardo Leegwater Simões <eduardo@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+dallo = { path = "../../dallo", default-features = false }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/modules/spender/src/lib.rs
+++ b/modules/spender/src/lib.rs
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#![feature(arbitrary_self_types)]
+#![no_std]
+#![no_main]
+
+#[global_allocator]
+static ALLOCATOR: dallo::HostAlloc = dallo::HostAlloc;
+
+#[derive(Default)]
+pub struct Spender;
+
+use dallo::{ModuleId, State};
+
+#[no_mangle]
+static SELF_ID: ModuleId = ModuleId::uninitialized();
+
+static mut STATE: State<Spender> = State::new(Spender);
+
+impl Spender {
+    pub fn get_limit_and_spent(&self) -> (u64, u64, u64, u64, u64) {
+        let self_id = dallo::self_id();
+
+        let limit = dallo::limit();
+        let spent_before = dallo::spent();
+
+        match dallo::caller().is_uninitialized() {
+            true => {
+                let (called_limit, called_spent, _, _, _): (
+                    u64,
+                    u64,
+                    u64,
+                    u64,
+                    u64,
+                ) = dallo::query(self_id, "get_limit_and_spent", ());
+
+                let spent_after = dallo::spent();
+                (limit, spent_before, spent_after, called_limit, called_spent)
+            }
+            false => (limit, spent_before, 0, 0, 0),
+        }
+    }
+}
+
+#[no_mangle]
+unsafe fn get_limit_and_spent(a: u32) -> u32 {
+    dallo::wrap_query(a, |_: ()| STATE.get_limit_and_spent())
+}


### PR DESCRIPTION
The calls work in the context of the running module. `spend` returns the points spent by the running module, while `limit` returns the point limit for the currently executing module.

Resolves: #46