### PR TITLE
Add host module support

### DIFF
--- a/dallo/src/lib.rs
+++ b/dallo/src/lib.rs
@@ -14,7 +14,9 @@ mod snap;
 pub use snap::snap;
 
 mod state;
-pub use state::{caller, emit, height, limit, query, query_raw, spent, State};
+pub use state::{
+    caller, emit, height, limit, native_query, query, query_raw, spent, State,
+};
 
 mod helpers;
 pub use helpers::*;

--- a/hatchery/src/lib.rs
+++ b/hatchery/src/lib.rs
@@ -13,7 +13,7 @@ mod storage_helpers;
 mod world;
 
 pub use error::Error;
-pub use world::{Event, Receipt, World};
+pub use world::{Event, NativeQuery, Receipt, World};
 
 #[macro_export]
 macro_rules! module_bytecode {

--- a/hatchery/src/world/native.rs
+++ b/hatchery/src/world/native.rs
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use std::collections::BTreeMap;
+use std::fmt::{self, Debug, Formatter};
+
+pub struct NativeQueries {
+    map: BTreeMap<&'static str, Box<dyn NativeQuery>>,
+}
+
+impl Debug for NativeQueries {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.map.keys()).finish()
+    }
+}
+
+impl NativeQueries {
+    pub fn new() -> Self {
+        NativeQueries {
+            map: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert<Q>(&mut self, name: &'static str, query: Q)
+    where
+        Q: 'static + NativeQuery,
+    {
+        self.map.insert(name, Box::new(query));
+    }
+
+    pub fn call(&self, name: &str, buf: &mut [u8], len: u32) -> Option<u32> {
+        self.map.get(name).map(|host_query| host_query(buf, len))
+    }
+}
+
+/// A query executable on the host.
+///
+/// The buffer containing the argument the module used to call the query
+/// together with its length are passed as arguments to the function, and should
+/// be processed first. Once this is done, the implementor should emplace the
+/// return of the query in the same buffer, and return its length.
+pub trait NativeQuery: Fn(&mut [u8], u32) -> u32 {}
+impl<F> NativeQuery for F where F: Fn(&mut [u8], u32) -> u32 {}

--- a/hatchery/tests/host.rs
+++ b/hatchery/tests/host.rs
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use hatchery::{module_bytecode, Error, Receipt, World};
+
+fn hash(buf: &mut [u8], len: u32) -> u32 {
+    assert_eq!(len, 4, "the length should come from the module as 4");
+
+    let mut num_bytes = [0; 4];
+    num_bytes.copy_from_slice(&buf[..4]);
+    let num = i32::from_le_bytes(num_bytes);
+
+    let hash = hash_num(num);
+    buf[..32].copy_from_slice(&hash);
+
+    32
+}
+
+fn hash_num(num: i32) -> [u8; 32] {
+    *blake3::hash(&num.to_le_bytes()).as_bytes()
+}
+
+#[test]
+pub fn host_hash() -> Result<(), Error> {
+    let mut world = World::ephemeral()?;
+
+    let id = world.deploy(module_bytecode!("host"))?;
+
+    world.register_native_query("hash", hash);
+
+    let h: Receipt<[u8; 32]> =
+        world.query(id, "hash", 42).expect("query should succeed");
+    assert_eq!(hash_num(42), *h);
+
+    Ok(())
+}

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "eventer",
     "everest",
     "fibonacci",
+    "host",
     "stack",
     "spender",
     "vector",

--- a/modules/host/Cargo.toml
+++ b/modules/host/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "host"
+version = "0.1.0"
+authors = [
+    "Eduardo Leegwater Simões <eduardo@dusk.network>",
+]
+edition = "2021"
+
+license = "MPL-2.0"
+
+[dependencies]
+dallo = { path = "../../dallo", default-features = false }
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/modules/host/src/lib.rs
+++ b/modules/host/src/lib.rs
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use dallo::{HostAlloc, ModuleId, State};
+#[global_allocator]
+static ALLOCATOR: HostAlloc = HostAlloc;
+
+pub struct Hoster;
+
+#[no_mangle]
+static SELF_ID: ModuleId = ModuleId::uninitialized();
+
+static mut STATE: State<Hoster> = State::new(Hoster);
+
+impl Hoster {
+    pub fn hash(&self, num: i32) -> [u8; 32] {
+        dallo::native_query("hash", num)
+    }
+}
+
+#[no_mangle]
+unsafe fn hash(arg_len: u32) -> u32 {
+    dallo::wrap_query(arg_len, |num| STATE.hash(num))
+}


### PR DESCRIPTION
This introduces a new host import `nq`, allowing modules to execute arbitrary queries that are executed on the host and defined upstream via the `NativeQuery` trait.

Resolves #49 