### PR TITLE
Set default module stack size to 1 WASM page

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "target"

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ modules: ## Build WASM modules
 	  -Z build-std=core,alloc,panic_abort \
 	  -Z build-std-features=panic_immediate_abort \
 	  --target wasm32-unknown-unknown
-	@mkdir -p modules/target/stripped
-	@find modules/target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" \
+	@mkdir -p target/stripped
+	@find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" \
 	 | xargs -I % basename % \
 	 | xargs -I % wasm-tools strip -a \
-	 	          modules/target/wasm32-unknown-unknown/release/% \
-	 	          -o modules/target/stripped/%
+	 	          target/wasm32-unknown-unknown/release/% \
+	 	          -o target/stripped/%
 
 test: modules assert-counter-module-small ## Run the tests
 	cargo test \
@@ -27,4 +27,4 @@ test: modules assert-counter-module-small ## Run the tests
 COUNTER_MODULE_BYTE_SIZE_LIMIT = 512
 
 assert-counter-module-small: modules
-	@test `wc -c modules/target/stripped/counter.wasm | sed 's/^[^0-9]*\([0-9]*\).*/\1/'` -lt $(COUNTER_MODULE_BYTE_SIZE_LIMIT);
+	@test `wc -c target/stripped/counter.wasm | sed 's/^[^0-9]*\([0-9]*\).*/\1/'` -lt $(COUNTER_MODULE_BYTE_SIZE_LIMIT);

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 modules: ## Build WASM modules
-	@cargo build \
+	@RUSTFLAGS="-C link-args=-zstack-size=65536" \
+	cargo build \
 	  --release \
       --manifest-path=modules/Cargo.toml \
 	  --color=always \

--- a/vmx/src/bytecode_macro.rs
+++ b/vmx/src/bytecode_macro.rs
@@ -7,10 +7,6 @@
 #[macro_export]
 macro_rules! module_bytecode {
     ($name:literal) => {
-        include_bytes!(concat!(
-            "../../modules/target/stripped/",
-            $name,
-            ".wasm"
-        ))
+        include_bytes!(concat!("../../target/stripped/", $name, ".wasm"))
     };
 }


### PR DESCRIPTION
This shows that module writers can control the stack size of their module by setting `link-args` to the appropriate value. In our case, for the tests we could probably do with an even smaller number than 1 WASM page.

This PR also ensure we build to the root `target` directory so as to facilitate a `make modules`-then-`cargo clean` workflow.