### PR TITLE
Make `wee_alloc` optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ modules: ## Build WASM modules
 	 	          -o target/stripped/%
 
 test: modules assert-counter-module-small ## Run the tests
-	cargo test \
+	@cargo test \
 	  --manifest-path=./vmx/Cargo.toml \
 	  --color=always
 

--- a/modules/box/Cargo.toml
+++ b/modules/box/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/callcenter/Cargo.toml
+++ b/modules/callcenter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/counter/Cargo.toml
+++ b/modules/counter/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/debugger/Cargo.toml
+++ b/modules/debugger/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/eventer/Cargo.toml
+++ b/modules/eventer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/everest/Cargo.toml
+++ b/modules/everest/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/fibonacci/Cargo.toml
+++ b/modules/fibonacci/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/host/Cargo.toml
+++ b/modules/host/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/micro/Cargo.toml
+++ b/modules/micro/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/self_snapshot/Cargo.toml
+++ b/modules/self_snapshot/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }

--- a/modules/spender/Cargo.toml
+++ b/modules/spender/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/modules/stack/Cargo.toml
+++ b/modules/stack/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 nstack = { git = "https://github.com/dusk-network/nstack", tag = "v0.0.0-hatchery" }
 ranno = { git = "https://github.com/dusk-network/ranno", tag = "v0.0.0-hatchery", default-features = false, features = ["alloc"] }
 

--- a/modules/vector/Cargo.toml
+++ b/modules/vector/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uplink = { path = "../../uplink", default-features = false }
+uplink = { path = "../../uplink", default-features = false, features = ["wee_alloc"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 rkyv = { version = "0.7", default-features = false, features = ["size_32", "alloc"] }
 bytecheck = { version = "0.6", default-features = false }
-wee_alloc = "0.4.5"
+wee_alloc = { version = "0.4", optional = true }
 
 [features]
 default = ["std"]

--- a/uplink/src/handlers.rs
+++ b/uplink/src/handlers.rs
@@ -34,6 +34,7 @@ fn panic(panic_info: &PanicInfo) -> ! {
 #[lang = "eh_personality"]
 extern "C" fn eh_personality() {}
 
+#[cfg(feature = "wee_alloc")]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 


### PR DESCRIPTION
The global allocator can either be set by the user, or by the uplink when selecting the `wee_alloc` feature.

Resolves #68