### PR TITLE
Last commits loaded only into (session's) fresh module' memories

### DIFF
--- a/vmx/src/session.rs
+++ b/vmx/src/session.rs
@@ -96,19 +96,21 @@ impl Session {
             )
             .expect("todo, error handling");
 
-            memory.set_freshness(NotFresh);
-
-            // if current commit exists, use it as memory image
-            if let Some(commit_path) = self.path_to_current_commit(&mod_id) {
-                let metadata = std::fs::metadata(commit_path.as_ref())
-                    .expect("todo - metadata error handling");
-                memory
-                    .grow_to(metadata.len() as u32)
-                    .expect("todo - grow error handling");
-                let (target_path, _) = self.vm.memory_path(&mod_id);
-                std::fs::copy(commit_path.as_ref(), target_path.as_ref())
-                    .expect("commit and memory paths exist");
+            if memory.freshness() == Fresh {
+                // if current commit exists, use it as memory image
+                if let Some(commit_path) = self.path_to_current_commit(&mod_id)
+                {
+                    let metadata = std::fs::metadata(commit_path.as_ref())
+                        .expect("todo - metadata error handling");
+                    memory
+                        .grow_to(metadata.len() as u32)
+                        .expect("todo - grow error handling");
+                    let (target_path, _) = self.vm.memory_path(&mod_id);
+                    std::fs::copy(commit_path.as_ref(), target_path.as_ref())
+                        .expect("commit and memory paths exist");
+                }
             }
+            memory.set_freshness(NotFresh);
             wrapped
         })
     }

--- a/vmx/tests/session_commit.rs
+++ b/vmx/tests/session_commit.rs
@@ -54,7 +54,7 @@ fn commit_restore() -> Result<(), Error> {
     session_2.transact::<(), ()>(id, "increment", ())?;
     session_2.transact::<(), ()>(id, "increment", ())?;
     let commit_2 = session_2.commit()?;
-    assert_eq!(vm.session().query::<(), i64>(id, "read_value", ())?, 0xfe);
+    assert_eq!(vm.session().query::<(), i64>(id, "read_value", ())?, 0xff);
 
     // restore commit 1
     let mut session_3 = vm.session();
@@ -64,7 +64,7 @@ fn commit_restore() -> Result<(), Error> {
     // restore commit 2
     let mut session_4 = vm.session();
     session_4.restore(&commit_2)?;
-    assert_eq!(session_4.query::<(), i64>(id, "read_value", ())?, 0xfe);
+    assert_eq!(session_4.query::<(), i64>(id, "read_value", ())?, 0xff);
     Ok(())
 }
 
@@ -126,7 +126,7 @@ fn multiple_commits() -> Result<(), Error> {
     session.transact::<(), ()>(id, "increment", ())?;
     let commit_2 = session.commit()?;
     let mut session = vm.session();
-    assert_eq!(session.query::<(), i64>(id, "read_value", ())?, 0xfe);
+    assert_eq!(session.query::<(), i64>(id, "read_value", ())?, 0xff);
 
     // restore commit 1
     session.restore(&commit_1)?;
@@ -134,6 +134,6 @@ fn multiple_commits() -> Result<(), Error> {
 
     // restore commit 2
     session.restore(&commit_2)?;
-    assert_eq!(session.query::<(), i64>(id, "read_value", ())?, 0xfe);
+    assert_eq!(session.query::<(), i64>(id, "read_value", ())?, 0xff);
     Ok(())
 }


### PR DESCRIPTION
Last commits loaded only into (session's) fresh module' memories

Solves #91
