### PR TITLE
Add host metadata support

### DIFF
--- a/modules/everest/src/lib.rs
+++ b/modules/everest/src/lib.rs
@@ -20,7 +20,7 @@ static mut STATE: State<Height> = State::new(Height);
 
 impl Height {
     pub fn get_height(&self) -> u64 {
-        uplink::height()
+        uplink::host_data::<u64>("height")
     }
 }
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -15,7 +15,8 @@ pub use snap::snap;
 
 mod state;
 pub use state::{
-    caller, height, host_query, limit, query, query_raw, spent, State,
+    caller, height, host_data, host_query, limit, query, query_raw, spent,
+    State,
 };
 
 mod helpers;

--- a/vmx/Cargo.toml
+++ b/vmx/Cargo.toml
@@ -13,9 +13,9 @@ wasmer-middlewares = { git = "https://github.com/wasmerio/wasmer", rev = "b501c1
 wasmer-compiler-singlepass = { git = "https://github.com/wasmerio/wasmer", rev = "b501c166" }
 bytecheck = "0.6"
 rkyv = { version = "0.7", features = ["size_32", "validation"] }
-parking_lot = "0.12.1"
-blake3 = "1.3.1"
-colored = "2.0.0"
+parking_lot = "0.12"
+blake3 = "1"
+colored = "2"
 libc = { version = "^0.2", default-features = false }
-region = { version = "3.0" }
-tempfile = "3.2.0"
+region = "3"
+tempfile = "3"

--- a/vmx/Cargo.toml
+++ b/vmx/Cargo.toml
@@ -16,7 +16,6 @@ rkyv = { version = "0.7", features = ["size_32", "validation"] }
 parking_lot = "0.12.1"
 blake3 = "1.3.1"
 colored = "2.0.0"
-wasmparser = "0.90.0"
 libc = { version = "^0.2", default-features = false }
 region = { version = "3.0" }
 tempfile = "3.2.0"

--- a/vmx/src/error.rs
+++ b/vmx/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     RuntimeError(wasmer::RuntimeError),
     SerializeError(Box<wasmer::SerializeError>),
     DeserializeError(Box<wasmer::DeserializeError>),
-    ParsingError(Box<wasmparser::BinaryReaderError>),
+    ParsingError(Box<wasmer::wasmparser::BinaryReaderError>),
     Trap(Box<wasmer_vm::Trap>),
     CompositeSerializerError(Box<Compo>),
     PersistenceError(std::io::Error),

--- a/vmx/src/imports.rs
+++ b/vmx/src/imports.rs
@@ -23,7 +23,8 @@ impl DefaultImports {
                 "caller" => Function::new_typed_with_env(store, &fenv, caller),
                 "q" => Function::new_typed_with_env(store, &fenv, q),
                 "t" => Function::new_typed_with_env(store, &fenv, t),
-                "nq" => Function::new_typed_with_env(store, &fenv, nq),
+                "hq" => Function::new_typed_with_env(store, &fenv, hq),
+                "hd" => Function::new_typed_with_env(store, &fenv, hd),
                 "host_debug" => Function::new_typed_with_env(store, &fenv, host_debug),
                 "emit" => Function::new_typed_with_env(store, &fenv, emit),
                 "limit" => Function::new_typed_with_env(store, &fenv, limit),
@@ -162,7 +163,7 @@ fn t(
     ret_len
 }
 
-fn nq(
+fn hq(
     mut fenv: FunctionEnvMut<Env>,
     name_ofs: i32,
     name_len: u32,
@@ -185,6 +186,30 @@ fn nq(
     instance
         .with_arg_buffer(|buf| env.host_query(&name, buf, arg_len))
         .expect("TODO: error handling")
+}
+
+fn hd(mut fenv: FunctionEnvMut<Env>, name_ofs: i32, name_len: u32) -> u32 {
+    let env = fenv.data_mut();
+
+    let instance = env.self_instance();
+
+    let name_ofs = name_ofs as usize;
+    let name_len = name_len as usize;
+
+    let name = instance.with_memory(|buf| {
+        // performance: use a dedicated buffer here?
+        core::str::from_utf8(&buf[name_ofs..][..name_len])
+            .expect("TODO, error out cleaner")
+            .to_owned()
+    });
+
+    let data = env.meta(&name).expect("the metadata should exist");
+
+    instance.with_arg_buffer(|buf| {
+        buf[..data.len()].copy_from_slice(&data);
+    });
+
+    data.len() as u32
 }
 
 fn emit(mut fenv: FunctionEnvMut<Env>, arg_len: u32) {

--- a/vmx/src/instance.rs
+++ b/vmx/src/instance.rs
@@ -49,17 +49,6 @@ pub(crate) struct Env {
     session: Session,
 }
 
-impl Env {
-    pub fn host_query(
-        &self,
-        name: &str,
-        buf: &mut [u8],
-        arg_len: u32,
-    ) -> Option<u32> {
-        self.session.host_query(name, buf, arg_len)
-    }
-}
-
 impl Deref for Env {
     type Target = Session;
 

--- a/vmx/tests/height.rs
+++ b/vmx/tests/height.rs
@@ -7,7 +7,6 @@
 use vmx::{module_bytecode, Error, VM};
 
 #[test]
-#[ignore]
 pub fn height() -> Result<(), Error> {
     let mut vm = VM::ephemeral()?;
 
@@ -15,7 +14,7 @@ pub fn height() -> Result<(), Error> {
 
     let mut session = vm.session();
 
-    for h in 0..1024 {
+    for h in 0u64..1024 {
         session.set_meta("height", h);
         let height: u64 = session.transact(id, "get_height", ())?;
         assert_eq!(height, h);


### PR DESCRIPTION
Host data can be anything that can be serialized and offered up to a
module for consumption, from the height of the blockchain - included as
an example in the tests, to complex data.

Resolves #81